### PR TITLE
Fixed Typo

### DIFF
--- a/pack/.minecraft/patchouli_books/hexmc_handbook/en_us/entries/boss_fights/underground.json
+++ b/pack/.minecraft/patchouli_books/hexmc_handbook/en_us/entries/boss_fights/underground.json
@@ -11,7 +11,7 @@
     {
       "type": "patchouli:crafting",
       "recipe": "bosses_of_mass_destruction:void_lily",
-      "text": "Usage: $(br2)$(item)Void Lily's$() are able to point to the direction of $(thing)The Underground Bosses$() arena"
+      "text": "Usage: $(br2)$(item)Void Lilies$() are able to point to the direction of $(thing)The Underground Bosses$() arena"
     }
   ]
 }


### PR DESCRIPTION
Changes "Void Lily's" to "Void Lilies"